### PR TITLE
chore: bump create-pull-request action to v8.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         git diff
     - name: Create Pull Request
       id: create_pr
-      uses: peter-evans/create-pull-request@v7.0.8
+      uses: peter-evans/create-pull-request@v8.1.0
       with:
         token: ${{ inputs.gh_token }}
         commit-message: |


### PR DESCRIPTION
## Summary
- bump `peter-evans/create-pull-request` from `v7.0.8` to `v8.1.0`

## Validation
- `act --container-architecture linux/amd64 --container-daemon-socket - --container-options "--memory 4g" workflow_dispatch -W .github/workflows/build.yml -j build -s GITHUB_TOKEN="$TOKEN"`
- result: success
