### PR TITLE
fix: remove unsupported checkout inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,6 @@ runs:
       uses: p6m7g8-actions/checkout@main
       with:
         fetch-depth: 0
-        ref: main
-        persist-credentials: false
     - name: Setup Node
       uses: p6m7g8-actions/node-yarn-setup@main
     - name: Upgrade Dependencies


### PR DESCRIPTION
- remove unsupported checkout inputs (ref, persist-credentials)\n- keeps fetch-depth only for p6m7g8-actions/checkout