### PR TITLE
fix: set authenticated origin before create-pull-request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ runs:
       shell: bash
       run: |
         git diff
+    - name: Configure authenticated git remote
+      shell: bash
+      run: |
+        git remote set-url origin "https://x-access-token:${{ inputs.gh_token }}@github.com/${{ github.repository }}.git"
     - name: Create Pull Request
       id: create_pr
       uses: peter-evans/create-pull-request@v8.1.0


### PR DESCRIPTION
- configure authenticated origin using gh_token before create-pull-request push/fetch operations