### PR TITLE
fix: use github token for create-pull-request auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,12 +27,12 @@ runs:
     - name: Configure authenticated git remote
       shell: bash
       run: |
-        git remote set-url origin "https://x-access-token:${{ inputs.gh_token }}@github.com/${{ github.repository }}.git"
+        git remote set-url origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
     - name: Create Pull Request
       id: create_pr
       uses: peter-evans/create-pull-request@v8.1.0
       with:
-        token: ${{ inputs.gh_token }}
+        token: ${{ github.token }}
         commit-message: |
           chore(deps): upgrade dependencies
         branch: github-actions/upgrade-main


### PR DESCRIPTION
- use workflow github.token for remote auth\n- use workflow github.token for create-pull-request