### PR TITLE
fix: use P6_A_GH_TOKEN first for upgrade PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,8 @@ author: "Philip M. Gollucci"
 
 inputs:
   gh_token:
-    description: "Fallback GitHub token (e.g., P6_A_GH_TOKEN)"
-    required: false
-    default: ""
+    description: "GitHub token used for PR creation (P6_A_GH_TOKEN)"
+    required: true
 
 runs:
   using: "composite"
@@ -29,8 +28,8 @@ runs:
       id: token
       uses: p6m7g8-actions/gh-token-normalize@main
       with:
-        preferred-token: ${{ github.token }}
-        fallback-token: ${{ inputs.gh_token }}
+        preferred-token: ${{ inputs.gh_token }}
+        fallback-token: ${{ github.token }}
         default-token: ${{ github.token }}
     - name: Configure authenticated git remote
       shell: bash


### PR DESCRIPTION
## Summary
- make `gh_token` required again
- prefer `gh_token` for PR creation token selection
- keep `github.token` as fallback only
- preserve reviewer/labels for auto-approve and merge-queue

## Why
PRs created with `github.token` can suppress downstream PR workflows in some repos.

## Testing
- yamllint action.yml (existing warning baseline only)