### PR TITLE
ci(build): report on merge-queue refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,15 @@ name: Build
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
+  # The merge queue needs `build` and `Lint PR title` to report on the queue
+  # ref, and merge_group is not dispatching (last such event org-wide was
+  # 2026-03-09). `claude-review` and `pull-request-lint` use the same trigger,
+  # but note the difference: they no-op on queue refs, whereas this workflow
+  # deliberately runs the FULL build there. Building the merged result is the
+  # entire point of a merge queue, so this one must not be stubbed out.
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}
@@ -12,8 +21,15 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # event_name is part of the key on purpose. A `push` to a gh-readonly-queue
+  # ref and a `merge_group` on that same ref both leave
+  # `github.event.pull_request.number` empty and both resolve `github.ref` to
+  # the queue ref, so without it the two share a group and cancel-in-progress
+  # cancels one of them. A cancelled required check dequeues the PR.
+  group: build-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # Only PR runs are cancellable. A cancelled required check dequeues the PR,
+  # so a queue-ref build must never be superseded by anything.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
**What:** brings `build.yml` byte-identical to the canonical distributor template, adding the queue-ref push trigger, the event-aware concurrency key, and PR-only cancellation.

**Why:** `merge_group` stopped dispatching org-wide. The last `merge_group` event anywhere in `p6m7g8-actions` was 2026-03-09, and every workflow is `active`, so this is not a disabled-workflow problem. The consequence is that `build` and `Lint PR title` never report on `gh-readonly-queue` refs, and the PR is evicted from the queue once the 7-minute check timeout expires. Measured directly: `p6-gh-release#13` was queued at 02:59:15 and evicted at 03:10:02 with `build` never reporting.

Adding the trigger by itself is not sufficient. Without `${{ github.event_name }}` in the concurrency key, a `push` to a `gh-readonly-queue` ref and a `merge_group` on that same ref resolve to the same group, because both leave `github.event.pull_request.number` empty and both fall back to the queue ref. They then cancel each other, and a cancelled required check dequeues the PR, which re-arms the identical eviction. Both halves are already fixed in the template; this repo simply never received it.

**Test plan:** `actionlint .github/workflows/build.yml` is clean. `diff` against the canonical template at `workflow_files/p6m7g8-actions/build.yml` in `p6-gh-distributor` reports no difference. `act` is not useful for a trigger-only change and was deliberately skipped. This PR is its own test: it can only merge through the queue if `build` reports on the queue ref.

**Dependencies:** Depends on PRs p6m7g8-actions/p6-gh-distributor#2, #4 and #6 (all merged), which established the canonical shape.
