### PR TITLE
refactor: adopt renamed action names

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ```yaml
       - name: Upgrade Deps
-        uses: p6m7g8-actions/cdk-construct-upgrade@main
+        uses: p6m7g8-actions/p6-cdk-construct-upgrade@main
         with:
           gh_token: ${{ secrets.P6_PGOLLUCCI_GH_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,11 @@ runs:
   using: "composite"
   steps:
     - name: Checkout main branch
-      uses: p6m7g8-actions/checkout@main
+      uses: p6m7g8-actions/gh-repo-checkout@main
       with:
         fetch-depth: 0
     - name: Setup Node
-      uses: p6m7g8-actions/node-yarn-setup@main
+      uses: p6m7g8-actions/p6-node-yarn-setup@main
     - name: Upgrade Dependencies
       shell: bash
       run: |
@@ -26,7 +26,7 @@ runs:
         git diff
     - name: Normalize GitHub token
       id: token
-      uses: p6m7g8-actions/gh-token-normalize@main
+      uses: p6m7g8-actions/gh-token-resolve@main
       with:
         preferred-token: ${{ github.token }}
         fallback-token: ${{ inputs.gh_token }}


### PR DESCRIPTION
**What:** Updates `uses:` refs to the renamed action repositories.

**Why:** 35 action repos in `p6m7g8-actions` were renamed to a consistent four-tier prefix scheme (`gh-`, `p6-gh-`, `p6-`, `p6df-`) with noun-verb ordering and no agent nouns. GitHub redirects the old names, so the rename broke nothing and this is cleanup rather than a fix. Updating the refs makes the dependency graph readable without chasing redirects.

**Test plan:** Validated on `p6m7g8-actions/p6-repo-build#24` before this batch was opened. Its `build` job reached "Set up job: success", which is where composite action resolution happens, confirming the new names resolve. This PR's own `build` re-confirms it for this repo's specific refs.

**Dependencies:** none. Every PR in this batch is independent.
